### PR TITLE
Pass the event name through the SNS event's "Subject"

### DIFF
--- a/lib/SNSEventEmitter.js
+++ b/lib/SNSEventEmitter.js
@@ -52,6 +52,9 @@ SNSEventEmitter.prototype.poll = function(callback){
                 handles = data.Messages.map(function(msg) {
                     var content = JSON.parse(msg.Body);
                     var args = JSON.parse(content.Message);
+                    if (!util.isArray(args)) {
+                      args = [ args ];
+                    }
                     args.unshift(content.Subject);
                     DistributedEventEmitter.prototype.emit.apply(self, args);
                     return msg.ReceiptHandle;

--- a/lib/SNSEventEmitter.js
+++ b/lib/SNSEventEmitter.js
@@ -47,11 +47,12 @@ SNSEventEmitter.prototype.poll = function(callback){
         }, function(err, data) {
             if (err) return callback(err);
             var handles = null;
-            if (data.Messages) {            
+            if (data.Messages) {
                 // fire events
                 handles = data.Messages.map(function(msg) {
                     var content = JSON.parse(msg.Body);
                     var args = JSON.parse(content.Message);
+                    args.unshift(content.Subject);
                     DistributedEventEmitter.prototype.emit.apply(self, args);
                     return msg.ReceiptHandle;
                 });
@@ -138,7 +139,7 @@ SNSEventEmitter.prototype.setPermissions = function(id, topicArn, queueArn, queu
     };
 
     self.SQS.setQueueAttributes({
-        QueueUrl: queueUrl, 
+        QueueUrl: queueUrl,
         Attributes: {
             Policy:JSON.stringify(policy)
         }
@@ -174,7 +175,7 @@ SNSEventEmitter.prototype.subscribe = function(topicArn, queueArn, callback){
 
 SNSEventEmitter.prototype.emit = function(event){
     var self = this;
-    var args = _.values(arguments);
+    var args = _.values(arguments).slice(1);
 
     this.getTopic(self.topic, function(err, topicArn) {
         var message = {


### PR DESCRIPTION
This makes the library usable with AWS generated events (e.g. "Amazon S3 Notification").